### PR TITLE
Fix: #12 check if url is set to determine if an array is an image

### DIFF
--- a/classes/Betterrest.php
+++ b/classes/Betterrest.php
@@ -134,7 +134,7 @@ final class Betterrest
             }
 
             // it is an array. if it is an image...
-            if (\Kirby\Toolkit\A::get($value, 'type') === 'image') {
+            if (\Kirby\Toolkit\A::get($value, 'type') === 'image' && \Kirby\Toolkit\A::get($value, 'url') !== null) {
                 return $betterrest->applySrcSet($value);
 
             } else { // ... call recursive


### PR DESCRIPTION
With the layout field Kirby introduces a block with type `image`. This is just a wrapper and not a file, so calling `srcset` on it causes an error.

To determine if a block is really an image I updated the corresponding if clause in the BetterRest class. It now checks for type and if an `url` key is set in the object/array (sorry, my coding background is more in JS, so I'm not sure about the correct PHP terminology).

This fixes my issue described in #12. Hope this fix makes sense. Looking forward to feedback.